### PR TITLE
fix: update incorrect nesting in README example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("Authentication error: %v\n", err)
 		return
-	
+	}
 	if success {
 		fmt.Println("Authentication successful!")
 	} else {
@@ -55,7 +55,6 @@ func main() {
 	} else {
 		fmt.Println("Serial authentication failed.")
 	}
-}
 }
 ```
 


### PR DESCRIPTION
I was reading over the README and noticed that the nesting in the first example meant that it wouldn't execute as expected as a closing brace was at the end of the function instead of an if block.

Cool project! Thanks for all the effort!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed an unnecessary blank line in the example code for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->